### PR TITLE
changed terraform-module-template tag to main

### DIFF
--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -20,7 +20,7 @@ jobs:
         with:
           token: ${{ secrets.AUTOMATION_TOKEN }}
           repository: 'boldlink/terraform-module-template'
-          ref: '0.4.1'
+          ref: 'main'
           path: .tmp
 
       - name: copy files


### PR DESCRIPTION
This PR changes terraform-module-template tag to main.
This will reduce the PRs created from changes only done to terraform-module-template repo. It also ensures that only the most recent files that have been merged to main are copied over.