### PR TITLE
Fix PR: Use github stable release for tf docs instead of terraform-docs.io which is down

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -26,7 +26,7 @@ jobs:
     - name: Install terraform binary #and extract only terraform-docs binary as extracting other files will override some module files
       run: |
         mkdir -p /home/runner/.local/bin
-        curl -sSLo ./terraform-docs.tar.gz https://terraform-docs.io/dl/${TF_DOCS_VER}/terraform-docs-${TF_DOCS_VER}-$(uname)-amd64.tar.gz
+        curl -sSLo ./terraform-docs.tar.gz https://github.com/terraform-docs/terraform-docs/releases/download/${TF_DOCS_VER}/terraform-docs-${TF_DOCS_VER}-$(uname)-amd64.tar.gz
         tar -zxvf terraform-docs.tar.gz terraform-docs
         chmod +x terraform-docs
         mv terraform-docs ${BIN_PATH}/terraform-docs


### PR DESCRIPTION
This PR has been created to use terraform-docs from github stable release instead of terraform-docs.io (which is down at the moment)