### PR TITLE
feat: fixed pre-commit infinite loop and allow 3 max runs

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -59,7 +59,7 @@ jobs:
       run: echo "date=$(date '+%d-%m-%Y %H:%M:%S')" >> $GITHUB_OUTPUT
 
     - name: Run pre-commit checks
-      run: for run in {1..3}; do pre-commit run -a && break done || exit 1
+      run: for run in {1..3}; do pre-commit run -a && break; done || exit 1
 
     - name: Push changes automatically!
       uses: EndBug/add-and-commit@v9

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -56,10 +56,18 @@ jobs:
 
     - name: Get current date
       id: date
-      run: echo "::set-output name=date::$(date '+%d-%m-%Y %H:%M:%S')"
+      run: echo "date=$(date '+%d-%m-%Y %H:%M:%S')" >> $GITHUB_OUTPUT
 
     - name: Run pre-commit checks
-      run: while ! pre-commit run -a ; do pre-commit run -a ; done || exit 0
+      run: |
+        counter=0
+        while ! pre-commit run -a && (( counter < 2 )); do
+          (( counter++ ))
+        done
+        
+        if (( counter == 2 )); then
+          exit 1
+        fi
 
     - name: Push changes automatically!
       uses: EndBug/add-and-commit@v9

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -59,15 +59,7 @@ jobs:
       run: echo "date=$(date '+%d-%m-%Y %H:%M:%S')" >> $GITHUB_OUTPUT
 
     - name: Run pre-commit checks
-      run: |
-        counter=0
-        while ! pre-commit run -a && (( counter < 2 )); do
-          (( counter++ ))
-        done
-        
-        if (( counter == 2 )); then
-          exit 1
-        fi
+      run: for run in {1..3}; do pre-commit run -a && break done || exit 1
 
     - name: Push changes automatically!
       uses: EndBug/add-and-commit@v9


### PR DESCRIPTION
This PR was created to fix the infinite `while` loop for the pre-commit workflow. It will only run for a max of 3 times.
The soon to be deprecated `set-output` feature was also replaced with github native output