### PR TITLE
fix: add CKV_TF_1 check to be skipped in checkov workflows

### DIFF
--- a/.github/workflows/checkov.yaml
+++ b/.github/workflows/checkov.yaml
@@ -26,6 +26,7 @@ jobs:
         with:
           directory: .
           framework: terraform
+          skip_check: CKV_TF_1
       
       - name: Slack Notification failure
         if: failure()


### PR DESCRIPTION
This PR adds an environment variable to skip CKV_TF_1 in all checkov runs.