### PR TITLE
feat: add PRs with documentation label to PR drafts

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -70,7 +70,7 @@ jobs:
   
       - uses: release-drafter/release-drafter@v5
         with:
-          publish: ${{ !contains(steps.get-merged-pr.outputs.labels, 'automerge') }}
+          publish: ${{ !contains(fromJSON('[ "automerge", "documentation"]'), steps.get-merged-pr-labels.outputs.labels) }}
           prerelease: false # Setting this option to true will have the upcoming release marked as a pre-release/ not production ready. By default we want it to remain as false.
           config-name: ${{ inputs.config-name }} 
         env:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -70,7 +70,7 @@ jobs:
   
       - uses: release-drafter/release-drafter@v5
         with:
-          publish: ${{ !contains(fromJSON('[ "automerge", "documentation"]'), steps.get-merged-pr-labels.outputs.labels) }}
+          publish: ${{ !contains(fromJSON('[ "automerge", "documentation"]'), steps.get-merged-pr.outputs.labels) }}
           prerelease: false # Setting this option to true will have the upcoming release marked as a pre-release/ not production ready. By default we want it to remain as false.
           config-name: ${{ inputs.config-name }} 
         env:


### PR DESCRIPTION
## Changes made in this PR
- Set any PR that has the `documentation` label to be exempted from creating a release, but instead create a PR draft.